### PR TITLE
charter: adding charter goal of metadata load/store extensiblity

### DIFF
--- a/charter.adoc
+++ b/charter.adoc
@@ -38,4 +38,8 @@ The Memory tagging TG’s deliverables include:
 	  managed runtime (OpenJDK and golang?) for memory tagging  
 	- Collect metrics on code size growth for major applications / SPEC benchmarks.
 
+. TG should look into possiblity of extensiblity of loads/stores on tag storage so that any new
+  metadata definition in future should be able to use same mechanism instead of creating new load/
+  store
+
 [1] https://docs.google.com/document/d/1XiMLTDj2JXb20pjM3Pm5wGnOli7skujIIXlFO2stFp8/edit#heading=h.rsyez7sin2vg


### PR DESCRIPTION
Tag management will required special loads/stores to tag storage. It'll be great if such loads/stores take metadata type input as well so that any future extension could use same mechanism instead of developing new loads and stores.